### PR TITLE
fix: default port for list and download

### DIFF
--- a/cmd_download.go
+++ b/cmd_download.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -183,7 +184,11 @@ func downloadCommand() cli.Command {
 			} else {
 				options = append(options, grpc.WithInsecure())
 			}
-			conn, err := grpc.Dial(c.String("a"), options...)
+			addr := c.String("a")
+			if !strings.Contains(addr, ":") {
+				addr += ":11111"
+			}
+			conn, err := grpc.Dial(addr, options...)
 			if err != nil {
 				log.Fatalf("cannot connect: %v", err)
 			}

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	proto "github.com/mattn/ft/proto"
@@ -62,7 +63,11 @@ func listCommand() cli.Command {
 			} else {
 				options = append(options, grpc.WithInsecure())
 			}
-			conn, err := grpc.Dial(c.String("a"), options...)
+			addr := c.String("a")
+			if !strings.Contains(addr, ":") {
+				addr += ":11111"
+			}
+			conn, err := grpc.Dial(addr, options...)
 			if err != nil {
 				log.Fatalf("cannot connect: %v", err)
 			}


### PR DESCRIPTION
according to README.md, we can download with `ft download -a 192.168.123.4` command, but this command does not work well.
so append default port of `ft serve` when given address isn't specified any port.